### PR TITLE
Fixed const that needed to be var

### DIFF
--- a/Camera.gd
+++ b/Camera.gd
@@ -1,16 +1,16 @@
 extends Camera
 
-const SENSITIVITY_Y = 0
-const INVERSION_MULT = 1
-const MAX_Y = 89
+var sensitivity_y = 0
+var inversion_mult = 1
+var max_y = 89
 
 func initializeComponents():
-	SENSITIVITY_Y = self.get_parent().Sensitivity_Y
-	MAX_Y = self.get_parent().Maximum_Y_Look
+	sensitivity_y = self.get_parent().Sensitivity_Y
+	max_y = self.get_parent().Maximum_Y_Look
 	if self.get_parent().Invert_Y_Axis:
-		INVERSION_MULT = 1
+		inversion_mult = 1
 	else:
-		INVERSION_MULT = -1
+		inversion_mult = -1
 
 func _ready():
 	self.initializeComponents()
@@ -19,8 +19,8 @@ func _ready():
 	
 func _input(event):
 	if event is InputEventMouseMotion:
-		if INVERSION_MULT * SENSITIVITY_Y * event.relative.y >= 0 and self.rotation_degrees.x >= MAX_Y:
+		if inversion_mult * sensitivity_y * event.relative.y >= 0 and self.rotation_degrees.x >= max_y:
 			return
-		if INVERSION_MULT * SENSITIVITY_Y * event.relative.y <= 0  and self.rotation_degrees.x <= -MAX_Y:
+		if inversion_mult * sensitivity_y * event.relative.y <= 0  and self.rotation_degrees.x <= -max_y:
 			return
-		rotate_x(INVERSION_MULT * SENSITIVITY_Y * event.relative.y)
+		rotate_x(inversion_mult * sensitivity_y * event.relative.y)


### PR DESCRIPTION
Fix for issue #4 
In Godot 3.1 and above, the Camera class does not currently work.

The issue is that it tries to assign these variables marked const.

This PR makes them just regular variables.